### PR TITLE
Add Argument Parser (argparse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@
 
 1. zipfile (built-in module)
 2. tqdm
+3. argparse
 
 ### Install the required dependencies:
 
 ```
-$ pip install tqdm
+$ pip install -r requirements.txt
 ```
 
 ### Usage:
 ```
-$ python zip_pass.py <ZipFileYouWantToCrack> <Wordlist>
+$ python zip_pass.py [-h] <ZipFileYouWantToCrack> <Wordlist>
 ```
 
 ### Example:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+tqdm
+argparse

--- a/zip_pass.py
+++ b/zip_pass.py
@@ -1,12 +1,28 @@
 from tqdm import tqdm
 
 import zipfile
-import sys
+
+import argparse
+from os import path
+
+
+def file_location(location: str) -> str:
+    if path.exists(location):
+        return location
+    else:
+        print(f"Error: Specified file does not exist -> {location}")
+        exit(1)
+
+
+parser = argparse.ArgumentParser(description="Brute force ZIP file passwords")
+parser.add_argument('zip_file', type=file_location, help="Password protected zip file")
+parser.add_argument('wordlist_file', type=file_location, help="Wordlist file")
+args = vars(parser.parse_args())
 
 # the password list path
-wordlist = sys.argv[2]
+wordlist = args['wordlist_file']
 # the zip file you want to crack its password
-zip_file = sys.argv[1]
+zip_file = args['zip_file']
 
 zip_file = zipfile.ZipFile(zip_file)
 # count the number of words in this wordlist

--- a/zip_pass.py
+++ b/zip_pass.py
@@ -6,6 +6,7 @@ import argparse
 from os import path
 
 
+# Function that checks if specified file exists (for argparse)
 def file_location(location: str) -> str:
     if path.exists(location):
         return location
@@ -14,10 +15,11 @@ def file_location(location: str) -> str:
         exit(1)
 
 
+# Create Argument Parser and parse specified arguments
 parser = argparse.ArgumentParser(description="Brute force ZIP file passwords")
 parser.add_argument('zip_file', type=file_location, help="Password protected zip file")
 parser.add_argument('wordlist_file', type=file_location, help="Wordlist file")
-args = vars(parser.parse_args())
+args = vars(parser.parse_args())  # Arguments are stored in `args` dictionary
 
 # the password list path
 wordlist = args['wordlist_file']


### PR DESCRIPTION
### I added:
* **Argument Parser** so if user specify arguments incorrectly there will be no unfriendly errors.
    * Option to use `-h` argument for help page.
* Check if specified files exists.
* Edited the `README.md` because of new `requirements.txt` file which stores all required pip packages.
* Added `argparse` prerequisite to `requirements.txt` file.

### The usage of script remains the same.